### PR TITLE
Randomly generate and store AES-GCM nonce/iv

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,10 +12,6 @@ module.exports = {
       "error",
       2
     ],
-    "linebreak-style": [
-      "error",
-      "unix"
-    ],
     "quotes": [
       "error",
       "double"

--- a/docs/index.html
+++ b/docs/index.html
@@ -11,6 +11,9 @@ const encryptionAlgorithm = "AES-GCM";
 const hashAlgorithm = "SHA-256";
 const iterations = 1000;
 const keyLength = 32;
+const saltLength = 8; // bytes
+const ivLength = 12; // bytes
+
 
 /* global marked */
 
@@ -84,24 +87,23 @@ function setEncrypted(text) {
   document.querySelector("#encrypted").innerHTML = text;
 }
 
-function arrayBufferToBase64(buffer) {
+function arrayToBase64(byteArray) {
   var binary = "";
-  const bytes = new Uint8Array(buffer);
-  const len = bytes.byteLength;
+  const len = byteArray.byteLength;
   for (var i = 0; i < len; i++) {
-    binary += String.fromCharCode(bytes[i]);
+    binary += String.fromCharCode(byteArray[i]);
   }
-  return window.btoa( binary );
+  return window.btoa(binary);
 }
 
-function base64ToArrayBuffer(base64) {
+function base64ToArray(base64) {
   var binary_string =  window.atob(base64);
   const len = binary_string.length;
   const bytes = new Uint8Array( len );
   for (var i = 0; i < len; i++)        {
     bytes[i] = binary_string.charCodeAt(i);
   }
-  return bytes.buffer;
+  return bytes;
 }
 
 function showDecryptedPage(decrypted) {
@@ -174,11 +176,19 @@ async function encryptClick() {
 }
 
 async function encrypt2Click() {
-  const salt = window.crypto.getRandomValues(new Uint32Array(2)).join("");
-  const iv = window.crypto.getRandomValues(new Uint8Array(32));
+  const salt = window.crypto.getRandomValues(new Uint8Array(saltLength));
+  const iv = window.crypto.getRandomValues(new Uint8Array(ivLength));
   var encrypted = await encryptData(getPlaintext(), getPasswordForEncrypt(), salt, iv);
-  encrypted = arrayBufferToBase64(encrypted);
-  setEncrypted(encrypted + "|" + salt + "|" + arrayBufferToBase64(iv));
+  encrypted = new Uint8Array(encrypted);
+
+  // combine the key derivation salt, the encryption initialisation vector and the encrypted content into 1 payload
+  const payload = new Uint8Array(salt.byteLength + iv.byteLength + encrypted.byteLength);
+
+  payload.set(new Uint8Array(salt)); // 8 bytes
+  payload.set(new Uint8Array(iv), saltLength); // 12 bytes
+  payload.set(encrypted, saltLength + ivLength); // the rest
+
+  setEncrypted(arrayToBase64(payload));
   scrubPlaintext();
   setInstructionsMessage();
   hideAll();
@@ -198,9 +208,15 @@ function finishDownloadClick() {
 }
 
 async function decryptClick() {
-  const [encrypted, salt, iv] = getEncrypted().split("|");
+  const payload = base64ToArray(getEncrypted());
+
+  // chop the payload into the key derivation salt, the encryption initialisation vector and the encrypted content
+  const salt = payload.slice(0, saltLength);
+  const iv = payload.slice(saltLength, saltLength + ivLength);
+  const encrypted = payload.slice(saltLength + ivLength);
+
   var plaintext = await decryptData(
-    base64ToArrayBuffer(encrypted), getPasswordForDecrypt(), salt, base64ToArrayBuffer(iv)
+    encrypted.buffer, getPasswordForDecrypt(), salt, iv.buffer
   ).catch(() => alert("Error with decryption"));
   plaintext = JSON.parse(plaintext);
   setPlaintext(plaintext);
@@ -3853,7 +3869,8 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 
     <button style="display: none; position: fixed; right: 1rem; bottom: 0;" id="create-button">Create another encrypted page</button>
 
-    <div style="position: fixed; left: 1rem; bottom: 1rem; font-size: 1rem; color: #aaa;">Code and more info @ <a href="https://github.com/jackcasey/stashd">github.com/jackcasey/stashd</a></div>
+    <div style="position: fixed; left: 1rem; bottom: 1rem; font-size: 1rem; color: #aaa;">v0.2.0 Code and more info @ <a href="https://github.com/jackcasey/stashd">github.com/jackcasey/stashd</a></div>
 </body>
 
 </html>
+

--- a/docs/index.html
+++ b/docs/index.html
@@ -10,7 +10,7 @@ const encryptionAlgorithm = "AES-GCM";
 // Key derivation from passphrase
 const hashAlgorithm = "SHA-256";
 const iterations = 1000;
-const keyLength = 48;
+const keyLength = 32;
 
 /* global marked */
 
@@ -25,11 +25,8 @@ async function getDerivation(salt, password, iterations, keyLength) {
   return derivation;
 }
 
-async function getKey(derivation) {
-  const keylen = 32;
-  const derivedKey = derivation.slice(0, keylen);
-  const iv = derivation.slice(keylen);
-  const importedEncryptionKey = await crypto.subtle.importKey("raw", derivedKey, { name: encryptionAlgorithm }, false, ["encrypt", "decrypt"]);
+async function getKey(derivation, iv) {
+  const importedEncryptionKey = await crypto.subtle.importKey("raw", derivation, { name: encryptionAlgorithm }, false, ["encrypt", "decrypt"]);
   return {
     key: importedEncryptionKey,
     iv: iv
@@ -49,16 +46,16 @@ async function decrypt(encryptedText, keyObject) {
   return textDecoder.decode(decryptedText);
 }
 
-async function encryptData(text, password, salt) {
+async function encryptData(text, password, salt, iv) {
   const derivation = await getDerivation(salt, password, iterations, keyLength);
-  const keyObject = await getKey(derivation);
+  const keyObject = await getKey(derivation, iv);
   const encryptedObject = await encrypt(JSON.stringify(text), keyObject);
   return encryptedObject;
 }
 
-async function decryptData(encryptedObject, password, salt) {
+async function decryptData(encryptedObject, password, salt, iv) {
   const derivation = await getDerivation(salt, password, iterations, keyLength);
-  const keyObject = await getKey(derivation);
+  const keyObject = await getKey(derivation, iv);
   const decryptedObject = await decrypt(encryptedObject, keyObject);
   return decryptedObject;
 }
@@ -105,10 +102,6 @@ function base64ToArrayBuffer(base64) {
     bytes[i] = binary_string.charCodeAt(i);
   }
   return bytes.buffer;
-}
-
-function getSalt() {
-  return window.crypto.getRandomValues(new Uint32Array(2)).join("");
 }
 
 function showDecryptedPage(decrypted) {
@@ -181,10 +174,11 @@ async function encryptClick() {
 }
 
 async function encrypt2Click() {
-  const salt = getSalt();
-  var encrypted = await encryptData(getPlaintext(), getPasswordForEncrypt(), salt);
+  const salt = window.crypto.getRandomValues(new Uint32Array(2)).join("");
+  const iv = window.crypto.getRandomValues(new Uint8Array(32));
+  var encrypted = await encryptData(getPlaintext(), getPasswordForEncrypt(), salt, iv);
   encrypted = arrayBufferToBase64(encrypted);
-  setEncrypted(encrypted + "|" + salt);
+  setEncrypted(encrypted + "|" + salt + "|" + arrayBufferToBase64(iv));
   scrubPlaintext();
   setInstructionsMessage();
   hideAll();
@@ -204,10 +198,10 @@ function finishDownloadClick() {
 }
 
 async function decryptClick() {
-  var encrypted = getEncrypted();
-  const salt = encrypted.split("|")[1];
-  encrypted = encrypted.split("|")[0];
-  var plaintext = await decryptData(base64ToArrayBuffer(encrypted), getPasswordForDecrypt(), salt).catch(() => alert("Error with decryption"));
+  const [encrypted, salt, iv] = getEncrypted().split("|");
+  var plaintext = await decryptData(
+    base64ToArrayBuffer(encrypted), getPasswordForDecrypt(), salt, base64ToArrayBuffer(iv)
+  ).catch(() => alert("Error with decryption"));
   plaintext = JSON.parse(plaintext);
   setPlaintext(plaintext);
   showDecryptedPage(plaintext);

--- a/page.html
+++ b/page.html
@@ -92,7 +92,7 @@
 
     <button style="display: none; position: fixed; right: 1rem; bottom: 0;" id="create-button">Create another encrypted page</button>
 
-    <div style="position: fixed; left: 1rem; bottom: 1rem; font-size: 1rem; color: #aaa;">Code and more info @ <a href="https://github.com/jackcasey/stashd">github.com/jackcasey/stashd</a></div>
+    <div style="position: fixed; left: 1rem; bottom: 1rem; font-size: 1rem; color: #aaa;">v0.2.0 Code and more info @ <a href="https://github.com/jackcasey/stashd">github.com/jackcasey/stashd</a></div>
 </body>
 
 </html>


### PR DESCRIPTION
I use a random initialisation vector / nonce for AES GCM instead of deriving it alongside the key. Then store it in base64 alongside the encrypted content, as with the salt used for the SHA-256 PBKDF2 key derivation to be used for decryption.

I think this addresses the concern in #1 correctly.